### PR TITLE
SL-5322, SL-5518

### DIFF
--- a/src/components/HtmlTag/ButtonWrapper/index.tsx
+++ b/src/components/HtmlTag/ButtonWrapper/index.tsx
@@ -61,6 +61,7 @@ export const ButtonWrapper: React.FC<ButtonProps> = (props) => {
             name: 'HtmlTag',
             component: 'HtmlTag',
             props: {
+              ...object.components[0].props,
               text: value,
             },
             components: [],
@@ -75,10 +76,22 @@ export const ButtonWrapper: React.FC<ButtonProps> = (props) => {
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value
       updateObject(object, {
-        props: {
+        components: [
+          {
+            name: 'HtmlTag',
+            component: 'HtmlTag',
+            props: {
+              ...object.components[0].props,
+              href: value,
+            },
+            components: [],
+          },
+        ],
+        props:{
           ...object.props,
-          href: value,
-        },
+          // Добавила аттрибут чтобы передать его в onClick
+          "data-href": value,
+        }
       })
     },
     [object, updateObject]

--- a/src/components/HtmlTag/index.tsx
+++ b/src/components/HtmlTag/index.tsx
@@ -197,11 +197,30 @@ export const HtmlTag: RedactorComponent = ({
     /**
      * Если у компонента есть props.children, то выводим props.children
      */
+    
+    // Добавила пустой обьект для хранения функции
+    let useclick = {};
+    // Проверяем тег элемента
+    if (tagLower === 'button') {
+      // Если элемент кнопка и у него есть аттрибут data-href, то добавляем функцию перехода по ссылке, указанной пользователем
+      if (object.props['data-href']) {
+        if (!inEditMode) {
+          useclick = {
+            onClick:() => {
+            window.location.href = object.props['data-href']
+            }
+          }
+        }
+      }
+    }
+    
     return (
       <Tag
         // @ts-expect-error
         ref={ref as (el: any) => void}
         {...tagPropsExt}
+        // Добавляем клик
+        {...useclick}
       >
         {object.props.children || childrenContent}
       </Tag>

--- a/src/hooks/useRedactorComponentInit/RedactorComponentWrapper/styles.ts
+++ b/src/hooks/useRedactorComponentInit/RedactorComponentWrapper/styles.ts
@@ -41,9 +41,8 @@ export const RedactorComponentWrapperStyled = styled.div`
 
   ${RedactorComponentWrapperButtonsStyled} {
     position: absolute;
-    bottom: calc(100% - 14px);
-    right: 50%;
-    transform: translateX(50%);
+    bottom: calc(100% - 5px);
+    right: 14px;
     display: flex;
   }
 
@@ -112,7 +111,7 @@ export const RedactorComponentWrapperGlobalStyled = createGlobalStyle`
     }
     
     &:hover {
-      transform: scale(1.2);
+      transform: scale(1.07);
     }
     
     &.${TopDirectionSelector} {

--- a/src/ui/AddWidgetButton/AddWidgetModal/buttons/AddHead/index.tsx
+++ b/src/ui/AddWidgetButton/AddWidgetModal/buttons/AddHead/index.tsx
@@ -1,3 +1,4 @@
+// !Убрала возможность добавлять компонент Head, т.к. он добавлялся пустым
 import React, { useEffect, useMemo, useState } from 'react'
 import { AddWidgetModalButtonStyled } from '../../styles'
 import { AddWidgetButtonButtonProps } from '../interfaces'

--- a/src/ui/AddWidgetButton/AddWidgetModal/buttons/EditorBlockTitleH1.tsx
+++ b/src/ui/AddWidgetButton/AddWidgetModal/buttons/EditorBlockTitleH1.tsx
@@ -2,17 +2,12 @@ import React, { useMemo } from 'react'
 import { CustomBlockButton } from './CustomBlock'
 import { AddWidgetButtonButtonProps } from './interfaces'
 import { RedactorComponentObject } from '../../../..'
-import { IconText } from './buttonIcons'
+import { IconTitleH1 } from './buttonIcons'
 
-export const EditorBlockText = (props: AddWidgetButtonButtonProps) => {
-  const title = useMemo(
-    () => (
-      <>
-        <IconText /> Текст
-      </>
-    ),
-    []
-  )
+export const EditorBlockTitleH1 = (props: AddWidgetButtonButtonProps) => {
+  const title = useMemo(() => (
+    <><IconTitleH1/> Главный заголовок</>
+  ), [])
 
   const component: RedactorComponentObject = {
     name: 'HtmlTag',
@@ -26,14 +21,14 @@ export const EditorBlockText = (props: AddWidgetButtonButtonProps) => {
         name: 'HtmlTag',
         component: 'HtmlTag',
         props: {
-          tag: 'p',
+          tag: 'h1',
         },
         components: [
           {
             name: 'HtmlTag',
             component: 'HtmlTag',
             props: {
-              text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+              text: 'Heading',
             },
             components: [],
           },
@@ -44,3 +39,4 @@ export const EditorBlockText = (props: AddWidgetButtonButtonProps) => {
 
   return <CustomBlockButton {...props} title={title} component={component} />
 }
+

--- a/src/ui/AddWidgetButton/AddWidgetModal/buttons/EditorBlockTitleH2.tsx
+++ b/src/ui/AddWidgetButton/AddWidgetModal/buttons/EditorBlockTitleH2.tsx
@@ -2,13 +2,13 @@ import React, { useMemo } from 'react'
 import { CustomBlockButton } from './CustomBlock'
 import { AddWidgetButtonButtonProps } from './interfaces'
 import { RedactorComponentObject } from '../../../..'
-import { IconText } from './buttonIcons'
+import { IconTitleH2 } from './buttonIcons'
 
-export const EditorBlockText = (props: AddWidgetButtonButtonProps) => {
+export const EditorBlockTitleH2 = (props: AddWidgetButtonButtonProps) => {
   const title = useMemo(
     () => (
       <>
-        <IconText /> Текст
+        <IconTitleH2 /> Второстепенный заголовок
       </>
     ),
     []
@@ -26,14 +26,14 @@ export const EditorBlockText = (props: AddWidgetButtonButtonProps) => {
         name: 'HtmlTag',
         component: 'HtmlTag',
         props: {
-          tag: 'p',
+          tag: 'h2',
         },
         components: [
           {
             name: 'HtmlTag',
             component: 'HtmlTag',
             props: {
-              text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+              text: 'Heading 2',
             },
             components: [],
           },

--- a/src/ui/AddWidgetButton/AddWidgetModal/buttons/buttonIcons.tsx
+++ b/src/ui/AddWidgetButton/AddWidgetModal/buttons/buttonIcons.tsx
@@ -1,5 +1,35 @@
 import React from 'react'
 
+export const IconTitleH1 = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M15 3.9v14.8q0 .4-.2.6a1 1 0 0 1-1.2 0l-.3-.6v-6.6H3.7v6.6q0 .4-.2.6a1 1 0 0 1-1.2 0l-.3-.6V4q0-.5.3-.6a1 1 0 0 1 1.2 0q.3.1.2.6v6.5h9.6V4q0-.5.3-.6a1 1 0 0 1 1.2 0q.3.1.3.6m6.5 5a1 1 0 0 0-.9 0l-3.5 2.7-.4.5a1 1 0 0 0 .4.9 1 1 0 0 0 1 0l2.2-1.7V20q0 .4.2.6a1 1 0 0 0 1.2 0q.3-.1.3-.6V10a1 1 0 0 0-.5-.8"
+      fill="#000"
+    />
+  </svg>
+)
+
+export const IconTitleH2 = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M13.3 4.8V18a.7.7 0 1 1-1.6 0v-5.9H3.6V18A.7.7 0 1 1 2 18V4.8a.8.8 0 0 1 1.5 0v5.8h8.3V4.8a.7.7 0 1 1 1.4 0m8.2 13.5h-3l3.1-4.2a3 3 0 1 0-5.2-2.9.7.7 0 1 0 1.4.6q0-.2.3-.5a1.5 1.5 0 1 1 2.3 1.9l-4 5.4a.7.7 0 0 0 .6 1.1h4.5a.7.7 0 1 0 0-1.4"
+      fill="#000"
+    />
+  </svg>
+)
+
 export const IconText = () => (
   <svg
     width="24"

--- a/src/ui/AddWidgetButton/AddWidgetModal/index.tsx
+++ b/src/ui/AddWidgetButton/AddWidgetModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { RedactorComponentObject } from '../../..'
-import { AddHeadWidgetButton } from './buttons/AddHead'
+// import { AddHeadWidgetButton } from './buttons/AddHead'
 import { AddButtonWidgetButton } from './buttons/AddButton'
 import { AddWidgetButtonCourse } from './buttons/AddWidgetButtonCourse'
 import { AddImageWidgetButton } from './buttons/AddImageWidgetButton'
@@ -11,7 +11,9 @@ import { AddWidgetModalProps } from './interfaces'
 import { AddWidgetModalStyled } from './styles'
 import { Button, ButtonProps } from '@procraft/ui/dist/Button'
 import { AddWidgetModalSavedBlocks } from './tabs/Saved'
-import { EditorBlockTextButton } from './buttons/EditorBlockText'
+import { EditorBlockTitleH1 } from './buttons/EditorBlockTitleH1'
+import { EditorBlockTitleH2 } from './buttons/EditorBlockTitleH2'
+import { EditorBlockText } from './buttons/EditorBlockText'
 import { EditorBlockAccordionButton } from './buttons/EditorBlockAccordion'
 
 enum TabState {
@@ -89,10 +91,13 @@ export const AddWidgetModal: React.FC<AddWidgetModalProps> = ({
       case TabState.default:
         tabContent = (
           <div role="secondaryButtons" className="vidgets">
-            <EditorBlockTextButton {...props} />
+            <EditorBlockTitleH1 {...props} />
+            <EditorBlockTitleH2 {...props} />
+            <EditorBlockText {...props} />
             <AddImageWidgetButton {...props} />
             <AddVideoWidgetButton {...props} />
-            <AddHeadWidgetButton {...props} />
+            {/* убрала возможность добавлять компонент Head, т.к. он добавлялся пустым */}
+            {/* <AddHeadWidgetButton {...props} /> */}
             <AddButtonWidgetButton {...props} />
             <AddWidgetButtonCourse {...props} />
             <EditorBlockAccordionButton {...props} />


### PR DESCRIPTION
### [SL-5322](https://soholms.youtrack.cloud/issue/SL-5322) Конструктор: пустой заголовок и некликабельная кнопка

**Заголовок:**
- Пока что убрала возможность добавлять компонент "Заголовок" (Head) на ленд, т.к. он добавляется пустым.
- Компонент "Текстовый блок", который содержал заголовок и текст заменила на отдельный компонент с заголовком 1-го уровня и отдельный компонент с текстовым блоком.
- Добавила компонент заголовок 2-го уровня

**Кнопка:**
- Поправила функцию onChangeLink - чтобы при вводе текста в поле с url в модальном окне редактирования кнопки был виден вводимый текст. Ранее текст не отображался и был виден только плейсхолдер
- Для кнопки добавила onClick, чтобы при клике на нее происходил переход в соответствии с указанным url. Ранее по клику на кнопку ничего не происходило (у кнопки `<button>` был атрибут href, но переход по нему никак не обрабатывался)

### [SL-5518](https://soholms.youtrack.cloud/issue/SL-5518) Конструктор: в режиме редактирования одни кнопки перекрываются другими:
- Кнопки взаимодействия перенесла в исходное положение - в правый верхний угол выбранного блока. 